### PR TITLE
docs: correction operator manual + metadoc (H519)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # BHS — Edgerton *Buddhist Hybrid Sanskrit Dictionary* (1953)
 
+_Created: 16-05-2026 · Last updated: 11-07-2026_
+
 Development and correction repository for **Franklin Edgerton's *Buddhist Hybrid Sanskrit Grammar and Dictionary*, vol. 2 (Dictionary)**, a specialized dictionary of Buddhist Hybrid Sanskrit, part of the [Cologne Digital Sanskrit Lexicon](https://www.sanskrit-lexicon.uni-koeln.de/) (CDSL). The canonical source text lives in [`csl-orig/v02/bhs/bhs.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/bhs/bhs.txt) (17,777 entries); this repository holds the development, correction, and enrichment work.
 
 A specialized lexicon of the non-classical Sanskrit of Buddhist texts; entries carry multilingual notes (French, German).
 
 ## Documentation
 
+- [docs/CORRECTION_MANUAL.md](https://github.com/sanskrit-lexicon/BHS/blob/main/docs/CORRECTION_MANUAL.md) — **operator manual**: the correction pipeline applied to BHS, the spellcheck error-mining + FR/DE language-classification workflow, headword normalization, the bhs-meta2 loop, symptom→cause→cure.
 - [CLAUDE.md](CLAUDE.md) — repository guide and data-format reference.
 - [DATA_DICTIONARY.md](DATA_DICTIONARY.md) — markup tag reference.
 - [CONTRIBUTING.md](CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

--- a/docs/CORRECTION_MANUAL.md
+++ b/docs/CORRECTION_MANUAL.md
@@ -1,0 +1,197 @@
+# BHS Correction Manual
+
+_Created: 11-07-2026 · Last updated: 11-07-2026_
+
+The operator manual for correction and enrichment work on Edgerton's
+*Buddhist Hybrid Sanskrit Dictionary* (1953, BHS→English, 17,777 entries):
+the correction pipeline self-contained, plus the three data workflows this
+repo owns — English-spellcheck error triage with French/German language
+classification (`eng_error_lang/`), headword normalization
+(`headwordmod/`), and the `bhs-meta2.txt` display-metadata upkeep (`meta/`)
+— and the per-issue pattern and completed prefaces OCR.
+
+Companion metadoc: [docs/CORRECTION_MANUAL.meta.md](https://github.com/sanskrit-lexicon/BHS/blob/main/docs/CORRECTION_MANUAL.meta.md).
+
+---
+
+## 1. Cheat-sheet — one correction, end to end
+
+```bash
+# layout: BHS + csl-orig + csl-pywork as siblings ($BASE/cologne convention)
+
+# 1. snapshot the canonical text (pin the commit in the issue readme)
+git -C $BASE/cologne/csl-orig show <hash>:v02/bhs/bhs.txt > temp_bhs_0.txt
+
+# 2. change file (paired lines, ';' comments; new/ins/del; UTF-8, NO BOM)
+#    NNN old <exact current line>
+#    NNN new <replacement line>
+
+# 3. apply
+python updateByLine.py temp_bhs_0.txt change_bhs_N.txt temp_bhs_1.txt
+
+# 4. rebuild + validate (from csl-pywork/v02/)
+sh generate_dict.sh bhs ../../bhs
+sh xmlchk_xampp.sh bhs
+
+# 5. DELIVER — org agents: correction queue → the ONE consolidated csl-orig
+#    PR ~monthly (/cologne-correction-queue + /cologne-batch-pr); direct
+#    csl-orig commits are the upstream-maintainer pattern only.
+#    Audit trail: diff_to_changes_dict.py → csl-corrections batch.
+```
+
+Full 8-stage discipline + every gotcha (BOM, `<LEND>`, CRLF, line-count
+mismatch, line drift, python3/xmllint):
+[csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
+
+## 2. Data-flow diagram
+
+```
+csl-orig/v02/bhs/bhs.txt   (canonical; SLP1 {#…#} + ENGLISH glosses {%…%};
+│    Edgerton's apparatus is MULTILINGUAL — French/German scholarship quoted
+│    inline, tagged <lang>; refs in 〔…〕 lenticular brackets)
+│
+├── eng_error_lang/  — SPELLCHECK-DRIVEN ERROR MINING (§3.1)
+│     bhs_error.txt        L:headword:suspect-word triples (English spellcheck
+│     │                    misses over the gloss text)
+│     ├─ triage → bhs_error_ok.txt / bhs_error_todo.txt
+│     └─ language classification: bhs_french.py / bhs_german.py
+│        (pyspellchecker EN/FR/DE lexicons) → bhs_{french,german}(_edit).txt,
+│        bhs_misc_edit / bhs_sanmisc_edit / bhs_ok_san
+│        → feeds <lang> markup + typo corrections (issue #3, closed)
+│
+├── headwordmod/  — HEADWORD NORMALIZATION (§3.2)
+│     bhshw0.txt (page,col:hw:L1,L2) → hw1.py (strip parentheticals, commas,
+│     hyphens, avagraha, one-off mojibake) → bhshw1.txt (+ _note audit)
+│     → diff vs the Cologne XML copy → dhavalmodification.txt
+│
+├── meta/  — bhs-meta2.txt UPKEEP (§3.3; open issue #5)
+│     check_ea1.py (extended-ascii census) + check_tags.py (tag census)
+│     → statistics → MANUAL revision of bhs-meta2.txt → copy back to csl-orig
+│
+├── issues/  — per-issue workspaces: issue1 (Andhrabharati corrections,
+│     with compare/litsrc/meta sub-passes) · issue3 (multilingual words) ·
+│     issue4 (ls-tag tooltip revision, OPEN — adjust_tooltip.py + Anna's
+│     abbreviation list) · markup_fix (org fixer family)
+│
+├── prefaces/  — front-matter OCR, COMPLETE (15 pages: title block,
+│     Edgerton's Preface, the full Bibliography & Abbreviations; EN + RU)
+│
+▼  csl-pywork build → bhs.xml → Cologne display / csl-app
+```
+
+## 3. The three data workflows
+
+### 3.1 English-error mining with language classification (`eng_error_lang/`)
+
+**The idea:** run the English gloss text through a spellchecker; every miss
+is either a typo, a Sanskrit form, or — Edgerton's specialty — a **French or
+German quotation** that needs `<lang>` markup rather than "fixing".
+`bhs_error.txt` holds the raw `L:headword:word` misses; triage splits them
+into `_ok` (legitimate) and `_todo`. `bhs_french.py` / `bhs_german.py` load
+pyspellchecker's EN + FR/DE word lists and classify the residue — a word
+unknown to English but known to German is a German-quotation candidate —
+producing the `_edit` review files. The closed
+[issue #3](https://github.com/sanskrit-lexicon/BHS/issues/3) ("words in
+different languages") is this workflow's delivered round; rerunning it after
+a big correction batch re-mines the text. Dependency: `pip install
+pyspellchecker` (the one third-party package in the repo).
+
+### 3.2 Headword normalization (`headwordmod/`)
+
+`hw1.py` (ejf 2013, utf-8 2014) normalizes the extracted headword list
+`bhshw0.txt` — stripping parenthetical variants, comma tails, hyphens,
+avagraha apostrophes, and three documented one-off mojibake bytes — into
+`bhshw1.txt` (+ `bhshw1_note.txt` audit). `hw1.sh` then diffs the result
+against the Cologne XML build's copy; the divergence list is
+`dhavalmodification.txt` (Dhaval's side of the reconciliation). This is a
+completed pass kept replayable; rerun only when headword policy changes.
+
+### 3.3 meta2 upkeep (`meta/`)
+
+`bhs-meta2.txt` (in csl-orig, beside the source) is the display-metadata
+file — the inventory of extended-ASCII characters and tags the display
+layer must know about. The loop
+([meta/readme.txt](https://github.com/sanskrit-lexicon/BHS/blob/main/meta/readme.txt)):
+copy fresh `bhs.txt` + `bhs-meta2.txt` → `check_ea1.py` (extended-ascii
+census) + `check_tags.py` (tag census, with a local-tags split) → revise
+`bhs-meta2.txt` **manually** against the statistics → copy back to csl-orig
+and rebuild. Open thread:
+[issue #5](https://github.com/sanskrit-lexicon/BHS/issues/5) (meta2 update).
+Run this loop after any batch that adds characters or tags.
+
+## 4. Per-issue corrections and prefaces
+
+`issues/issueNNN/` follows the standard Cologne pattern — pin the input by
+commit hash (issue4's readme records `bf5bfd16` exactly; do the same),
+transform incrementally, keep change files + readme, rebuild + validate,
+deliver per §1 step 5. The open
+[issue #4](https://github.com/sanskrit-lexicon/BHS/issues/4) (ls-tag
+tooltip revision, `adjust_tooltip.py` + Anna's curated abbreviation list)
+is the live workspace. `prefaces/` is complete — 15 pages (title block,
+Preface, the dense two-column Bibliography & Abbreviations) in EN + RU; the
+README's OCR notes record the main-thread-only constraint for this
+dictionary's scans.
+
+## 5. Environment & prerequisites
+
+- **Python 3**; `pip install pyspellchecker` for the §3.1 classifiers
+  (everything else stdlib); `sh` via Git Bash on Windows.
+- **Sibling repos:** csl-orig (canonical `bhs.txt` + `bhs-meta2.txt`),
+  csl-pywork (build/validation), csl-corrections (audit + queue).
+- Historical logs use the maintainer XAMPP layout — substitute your paths.
+
+## 6. Symptom → cause → cure
+
+| Symptom | Cause | Cure |
+|---|---|---|
+| Spellcheck flags a "typo" that is French/German | Edgerton quotes FR/DE scholarship inline | §3.1 classification first; the fix is `<lang>` markup, not an English "correction" |
+| A flagged word is Anglicized Sanskrit | Edgerton's citation style | `bhs_ok_san` / `_sanmisc` territory — never "correct" it to dictionary English |
+| `updateByLine.py` mismatch | Change file built against a different bhs.txt state | Re-pin by commit hash (the issue4 pattern) and rebuild the change file |
+| Display shows a raw tag or lost character after a batch | `bhs-meta2.txt` not updated for new tags/characters | Run the §3.3 meta loop; issue #5 is the standing tracker |
+| `〔…〕` brackets look like corruption | The lenticular brackets are BHS's reference-locus markup by design | Leave them; they are load-bearing for `<ls>` tooltips |
+| Headword diff vs XML copy is non-empty | Expected — that's `dhavalmodification.txt`'s purpose (reconciliation input) | Review, don't force to zero |
+| `ModuleNotFoundError: spellchecker` | The one pip dependency | `pip install pyspellchecker` |
+| Tempted to commit straight to csl-orig | The no-noise delivery rule | Queue it; ONE batched PR ~monthly (§1 step 5) |
+| An old issue's fix seems obvious | May already be adjudicated | csl-corrections CFR/batch-history preflight first |
+
+## 7. Glossary
+
+| Term | Meaning |
+|---|---|
+| BHS | Buddhist Hybrid Sanskrit — the non-classical Sanskrit of Buddhist texts Edgerton codified |
+| `〔…〕` | Lenticular brackets around reference loci (page.line of the quoted text editions) |
+| `<lang>` | Markup for non-English apparatus words (Skt., Pali, French, German quotations) |
+| meta2 (`bhs-meta2.txt`) | The per-dictionary display-metadata file (extended-ascii + tag inventory) living in csl-orig |
+| error triage | The `bhs_error → _ok/_todo → language classification` review chain of §3.1 |
+| avagraha | The `'` elision mark — stripped in headword normalization |
+| `bhshw0/1.txt` | Raw vs normalized headword lists (page,col:hw:L-range format) |
+| `dhavalmodification.txt` | The headword divergence list vs the Cologne XML copy — reconciliation input |
+| change file | Line-addressed `NNN old`/`NNN new` (+ `ins`/`del`) edit record |
+| batched PR | The agent delivery unit into csl-orig: everything queued, one consolidated PR ~monthly |
+
+## 8. Maintainer appendix
+
+- **Live vs finished:** open = tooltip revision (#4), meta2 update (#5),
+  semantic line breaks (#2), the docs-pass (#7 — this manual is its core
+  deliverable). Finished = AB corrections (#1), multilingual words (#3),
+  markup oddities (#6), prefaces, the headwordmod pass.
+- **Observed quirks** (11-07-2026, while writing this manual): (1) the
+  README and CLAUDE.md "Contents" tables describe the working dirs as
+  "`eng_error_lang/` working files" — circular labels; this manual's §3 is
+  the missing description; (2) `hw1.py` hardcodes three one-off mojibake
+  fixes (`s\xa4`, `\x85yenaiva`…) — historical bytes, don't generalize from
+  them; (3) the README lacked the org dated header until this PR (added,
+  with the git creation date 16-05-2026); (4) `meta/readme.txt` line 24
+  echoes a count from a *different* file (`temp_bhs_ab_1.txt`) — copy-paste
+  residue in the log.
+- **Cross-repo edges:** csl-orig (canonical text + meta2), csl-pywork
+  (build), csl-corrections (audit + queue), the markup_fix family shared
+  with BOP/PWG/PWK/LRV.
+- **Issue taxonomy:** dictionary-repo taxonomy — see
+  [CLAUDE.md](https://github.com/sanskrit-lexicon/BHS/blob/main/CLAUDE.md)
+  and [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/BHS/blob/main/DATA_DICTIONARY.md)
+  for the tag reference.
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/docs/CORRECTION_MANUAL.meta.md
+++ b/docs/CORRECTION_MANUAL.meta.md
@@ -1,0 +1,69 @@
+# CORRECTION_MANUAL.md — metadoc
+
+_Created: 11-07-2026 · Last updated: 11-07-2026_
+
+Companion record for
+[docs/CORRECTION_MANUAL.md](https://github.com/sanskrit-lexicon/BHS/blob/main/docs/CORRECTION_MANUAL.md).
+
+## Purpose
+
+The runbook over BHS's working dirs: the correction pipeline applied to
+Edgerton, and the three repo-owned data workflows finally described
+(spellcheck error-mining with FR/DE language classification; headword
+normalization; the bhs-meta2 display-metadata loop), plus the per-issue
+pattern and prefaces.
+
+## Audience
+
+- An operator preparing a BHS correction for the monthly batch.
+- A contributor picking up the open threads (#4 tooltips, #5 meta2,
+  #2 semantic line breaks).
+- Anyone rerunning the error-mining pass after a big correction batch.
+
+## Provenance
+
+Authored 11-07-2026 by Fable 5 (`claude-fable-5`) under handoff
+[H519-Fable_BHS_correction_pipeline_manual_10.07.26](https://github.com/gasyoun/Uprava/blob/main/handoffs/H519-Fable_BHS_correction_pipeline_manual_10.07.26.md)
+(the H501–H531 per-repo manuals programme, Litpam-Indexator MANUAL.md gold
+standard). Content read from the meta/issue readmes, the workflow scripts
+(`hw1.py`, `bhs_german.py`, `check_*.py`, `adjust_tooltip.py` context),
+README/CLAUDE.md/DATA_DICTIONARY, and the canonical correction-workflow doc
+— none invented. Closes the core of
+[issue #7](https://github.com/sanskrit-lexicon/BHS/issues/7) (docs-pass).
+
+## Ranked improvement backlog
+
+| # | Item | Status |
+|---|---|---|
+| 1 | Replace the circular "working files" labels in README/CLAUDE.md Contents tables with the §3 one-liners | open |
+| 2 | Finish the tooltip revision ([issue #4](https://github.com/sanskrit-lexicon/BHS/issues/4)) — the live workspace | open (owned by issue) |
+| 3 | Run the meta2 loop ([issue #5](https://github.com/sanskrit-lexicon/BHS/issues/5)) after the next correction batch | open (owned by issue) |
+| 4 | Annotate the copy-paste count residue in `meta/readme.txt` | open |
+| 5 | A rerun note for §3.1 (pyspellchecker version pin — lexicon drift changes the miss set between runs) | open |
+
+## Known limitations
+
+- The scholarly adjudication of flagged words (typo vs Edgerton's usage vs
+  quotation) is judgment outside this manual; §3.1 documents the mechanics
+  and the review files.
+- `adjust_tooltip.py` internals are not decoded — issue4's readme is the
+  working log of record.
+- The build side is the canonical workflow doc's territory.
+
+## Related documents
+
+- [README.md](https://github.com/sanskrit-lexicon/BHS/blob/main/README.md) — repo overview (dated header added in this PR)
+- [CLAUDE.md](https://github.com/sanskrit-lexicon/BHS/blob/main/CLAUDE.md) + [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/BHS/blob/main/DATA_DICTIONARY.md) — format references
+- Working logs: [meta/readme.txt](https://github.com/sanskrit-lexicon/BHS/blob/main/meta/readme.txt) · [issues/issue4/readme.txt](https://github.com/sanskrit-lexicon/BHS/blob/main/issues/issue4/readme.txt)
+- [csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md) — the canonical 8-stage reference
+- Sibling manuals: [csl-orig CORRECTION_MANUAL](https://github.com/sanskrit-lexicon/csl-orig/blob/main/docs/CORRECTION_MANUAL.md) (H515, delivery side) · [BOP CORRECTION_MANUAL](https://github.com/sanskrit-lexicon/BOP/blob/main/docs/CORRECTION_MANUAL.md) (H516, same programme)
+
+## Revision history
+
+| Date | Change | By |
+|---|---|---|
+| 11-07-2026 | Initial version (H519) | Fable 5 (`claude-fable-5`) |
+
+---
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Executes [H519-Fable_BHS_correction_pipeline_manual_10.07.26](https://github.com/gasyoun/Uprava/blob/main/handoffs/H519-Fable_BHS_correction_pipeline_manual_10.07.26.md) (H501-H531 manuals programme, Litpam gold-standard shape).

Adds:
- [docs/CORRECTION_MANUAL.md](https://github.com/sanskrit-lexicon/BHS/blob/h519-correction-manual/docs/CORRECTION_MANUAL.md) - cheat-sheet (change file -> updateByLine -> generate/xmlchk -> queue-then-batched-PR delivery), data-flow diagram, and **the three repo-owned workflows finally described** (the README/CLAUDE Contents tables label them circularly as "working files"): spellcheck error-mining with FR/DE language classification via pyspellchecker (Edgerton quotes French/German scholarship - flagged "typos" become `<lang>` markup, not corrections), headword normalization (`hw1.py` -> `dhavalmodification.txt` reconciliation), the `bhs-meta2.txt` display-metadata loop (open issue #5). Per-issue pattern (live workspace: issue #4 tooltips), prefaces (complete, 15 pp.), environment, symptom->cause->cure, glossary, maintainer appendix. Core deliverable of the [issue #7](https://github.com/sanskrit-lexicon/BHS/issues/7) docs-pass.
- [docs/CORRECTION_MANUAL.meta.md](https://github.com/sanskrit-lexicon/BHS/blob/h519-correction-manual/docs/CORRECTION_MANUAL.meta.md) - metadoc with ranked backlog.
- README: org dated header added (git creation date 16-05-2026) + manual linked first in Documentation.

**Quirks flagged**: the circular "working files" labels; hw1.py's three hardcoded one-off mojibake fixes (historical bytes, not a pattern); a copy-paste count residue in meta/readme.txt; pyspellchecker lexicon drift as a rerun caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)